### PR TITLE
Fix: empty event type defaults to querying for all known event types

### DIFF
--- a/example/Nullify Demo Dashboard.json
+++ b/example/Nullify Demo Dashboard.json
@@ -1,8 +1,8 @@
 {
   "__inputs": [
     {
-      "name": "DS_NUL.DEV.NULLIFY.AI",
-      "label": "nul.dev.nullify.ai",
+      "name": "DS_NULLIFY",
+      "label": "Nullify",
       "description": "",
       "type": "datasource",
       "pluginId": "nullify-grafana-datasource",
@@ -27,7 +27,7 @@
       "type": "datasource",
       "id": "nullify-grafana-datasource",
       "name": "Nullify",
-      "version": "1.0.0"
+      "version": "0.0.0"
     },
     {
       "type": "panel",
@@ -62,7 +62,7 @@
     {
       "datasource": {
         "type": "nullify-grafana-datasource",
-        "uid": "${DS_NUL.DEV.NULLIFY.AI}"
+        "uid": "${DS_NULLIFY}"
       },
       "fieldConfig": {
         "defaults": {
@@ -232,10 +232,14 @@
         {
           "datasource": {
             "type": "nullify-grafana-datasource",
-            "uid": "${DS_NUL.DEV.NULLIFY.AI}"
+            "uid": "${DS_NULLIFY}"
           },
           "endpoint": "sast/summary",
-          "queryParameters": {},
+          "queryParameters": {
+            "githubRepositoryIdsOrQueries": [
+              "$repository"
+            ]
+          },
           "refId": "A"
         }
       ],
@@ -316,7 +320,7 @@
     {
       "datasource": {
         "type": "nullify-grafana-datasource",
-        "uid": "${DS_NUL.DEV.NULLIFY.AI}"
+        "uid": "${DS_NULLIFY}"
       },
       "fieldConfig": {
         "defaults": {
@@ -395,10 +399,14 @@
         {
           "datasource": {
             "type": "nullify-grafana-datasource",
-            "uid": "${DS_NUL.DEV.NULLIFY.AI}"
+            "uid": "${DS_NULLIFY}"
           },
           "endpoint": "secrets/events",
-          "queryParameters": {},
+          "queryParameters": {
+            "githubRepositoryIdsOrQueries": [
+              "$repository"
+            ]
+          },
           "refId": "A"
         }
       ],
@@ -448,7 +456,7 @@
     {
       "datasource": {
         "type": "nullify-grafana-datasource",
-        "uid": "${DS_NUL.DEV.NULLIFY.AI}"
+        "uid": "${DS_NULLIFY}"
       },
       "fieldConfig": {
         "defaults": {
@@ -526,10 +534,14 @@
           "constant": 6.5,
           "datasource": {
             "type": "nullify-grafana-datasource",
-            "uid": "${DS_NUL.DEV.NULLIFY.AI}"
+            "uid": "${DS_NULLIFY}"
           },
           "endpoint": "sast/summary",
-          "queryParameters": {},
+          "queryParameters": {
+            "githubRepositoryIdsOrQueries": [
+              "$repository"
+            ]
+          },
           "refId": "A"
         }
       ],
@@ -572,7 +584,7 @@
     {
       "datasource": {
         "type": "nullify-grafana-datasource",
-        "uid": "${DS_NUL.DEV.NULLIFY.AI}"
+        "uid": "${DS_NULLIFY}"
       },
       "fieldConfig": {
         "defaults": {
@@ -651,10 +663,14 @@
         {
           "datasource": {
             "type": "nullify-grafana-datasource",
-            "uid": "${DS_NUL.DEV.NULLIFY.AI}"
+            "uid": "${DS_NULLIFY}"
           },
           "endpoint": "secrets/events",
-          "queryParameters": {},
+          "queryParameters": {
+            "githubRepositoryIdsOrQueries": [
+              "$repository"
+            ]
+          },
           "refId": "A"
         }
       ],
@@ -704,7 +720,7 @@
     {
       "datasource": {
         "type": "nullify-grafana-datasource",
-        "uid": "${DS_NUL.DEV.NULLIFY.AI}"
+        "uid": "${DS_NULLIFY}"
       },
       "fieldConfig": {
         "defaults": {
@@ -781,10 +797,14 @@
         {
           "datasource": {
             "type": "nullify-grafana-datasource",
-            "uid": "${DS_NUL.DEV.NULLIFY.AI}"
+            "uid": "${DS_NULLIFY}"
           },
           "endpoint": "sast/summary",
-          "queryParameters": {},
+          "queryParameters": {
+            "githubRepositoryIdsOrQueries": [
+              "$repository"
+            ]
+          },
           "refId": "A"
         }
       ],
@@ -839,7 +859,7 @@
     {
       "datasource": {
         "type": "nullify-grafana-datasource",
-        "uid": "${DS_NUL.DEV.NULLIFY.AI}"
+        "uid": "${DS_NULLIFY}"
       },
       "fieldConfig": {
         "defaults": {
@@ -915,10 +935,14 @@
         {
           "datasource": {
             "type": "nullify-grafana-datasource",
-            "uid": "${DS_NUL.DEV.NULLIFY.AI}"
+            "uid": "${DS_NULLIFY}"
           },
           "endpoint": "secrets/summary",
-          "queryParameters": {},
+          "queryParameters": {
+            "githubRepositoryIdsOrQueries": [
+              "$repository"
+            ]
+          },
           "refId": "A"
         }
       ],
@@ -947,7 +971,7 @@
     {
       "datasource": {
         "type": "nullify-grafana-datasource",
-        "uid": "${DS_NUL.DEV.NULLIFY.AI}"
+        "uid": "${DS_NULLIFY}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1025,10 +1049,14 @@
         {
           "datasource": {
             "type": "nullify-grafana-datasource",
-            "uid": "${DS_NUL.DEV.NULLIFY.AI}"
+            "uid": "${DS_NULLIFY}"
           },
           "endpoint": "sast/events",
-          "queryParameters": {},
+          "queryParameters": {
+            "githubRepositoryIdsOrQueries": [
+              "$repository"
+            ]
+          },
           "refId": "A"
         }
       ],
@@ -1038,7 +1066,7 @@
     {
       "datasource": {
         "type": "nullify-grafana-datasource",
-        "uid": "${DS_NUL.DEV.NULLIFY.AI}"
+        "uid": "${DS_NULLIFY}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1173,10 +1201,14 @@
         {
           "datasource": {
             "type": "nullify-grafana-datasource",
-            "uid": "${DS_NUL.DEV.NULLIFY.AI}"
+            "uid": "${DS_NULLIFY}"
           },
           "endpoint": "sca/summary",
-          "queryParameters": {},
+          "queryParameters": {
+            "githubRepositoryIdsOrQueries": [
+              "$repository"
+            ]
+          },
           "refId": "A"
         }
       ],
@@ -1245,7 +1277,31 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {},
+        "datasource": {
+          "type": "nullify-grafana-datasource",
+          "uid": "${DS_NULLIFY}"
+        },
+        "definition": "Nullify Repository Query",
+        "description": "Filter for the repositories for which to query data",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Repository",
+        "multi": true,
+        "name": "repository",
+        "options": [],
+        "query": {
+          "queryType": "Repository"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
   },
   "time": {
     "from": "now-7d",
@@ -1255,6 +1311,6 @@
   "timezone": "",
   "title": "Nullify Demo Dashboard",
   "uid": "ecf0f5c8-bf81-479a-b72f-94b5c2855d04",
-  "version": 6,
+  "version": 2,
   "weekStart": ""
 }

--- a/provisioning/datasources/datasources.yml
+++ b/provisioning/datasources/datasources.yml
@@ -1,7 +1,7 @@
 apiVersion: 1
 
 datasources:
-  - name: 'grafana'
+  - name: 'Nullify Datasource'
     type: 'nullify-grafana-datasource'
     access: proxy
     isDefault: false

--- a/src/api/sastEvents.ts
+++ b/src/api/sastEvents.ts
@@ -261,7 +261,7 @@ interface SastEventsApiRequest {
   fromTime?: string; // ISO string
   fromEvent?: string;
   numItems?: number; //max 100
-  sort?: "asc" | "desc";
+  sort?: 'asc' | 'desc';
 }
 
 export const processSastEvents = async (
@@ -296,7 +296,7 @@ export const processSastEvents = async (
           request_params: params,
           response: response,
           data_validation_error: parseResult.error,
-        }
+        },
       };
     }
 
@@ -320,13 +320,21 @@ export const processSastEvents = async (
   return createDataFrame({
     refId: queryOptions.refId,
     fields: [
-      { name: 'id', type: FieldType.string, values: events.map((event) => event.id) },
+      {
+        name: 'id',
+        type: FieldType.string,
+        values: events.map((event) => event.id),
+      },
       {
         name: 'time',
         type: FieldType.time,
         values: events.map((event) => new Date(event.timestampUnix * 1000)),
       },
-      { name: 'type', type: FieldType.string, values: events.map((event) => event.type) },
+      {
+        name: 'type',
+        type: FieldType.string,
+        values: events.map((event) => event.type),
+      },
       {
         name: 'numFindings',
         type: FieldType.number,

--- a/src/api/sastEvents.ts
+++ b/src/api/sastEvents.ts
@@ -255,8 +255,9 @@ const SastEventsApiResponseSchema = z.object({
 type SastEventsEvent = z.infer<typeof SastEventsEventSchema>;
 
 interface SastEventsApiRequest {
+  githubRepositoryId?: number[];
   branch?: string;
-  githubRepositoryIds?: string;
+  eventType?: string[];
   fromTime?: string; // ISO string
   fromEvent?: string;
   numItems?: number; //max 100
@@ -273,11 +274,11 @@ export const processSastEvents = async (
   for (let i = 0; i < MAX_API_REQUESTS; ++i) {
     const params: SastEventsApiRequest = {
       ...(queryOptions.queryParameters.githubRepositoryIds
-        ? { githubRepositoryIds: queryOptions.queryParameters.githubRepositoryIds.join(',') }
+        ? { githubRepositoryId: queryOptions.queryParameters.githubRepositoryIds }
         : {}),
       ...(queryOptions.queryParameters.branch ? { branch: queryOptions.queryParameters.branch } : {}),
       ...(queryOptions.queryParameters.eventTypes && queryOptions.queryParameters.eventTypes.length > 0
-        ? { eventTypes: queryOptions.queryParameters.eventTypes.join(',') }
+        ? { eventType: queryOptions.queryParameters.eventTypes }
         : {}),
       ...(prevEventId ? { fromEvent: prevEventId } : { fromTime: range.from.toISOString() }),
       sort: 'asc',

--- a/src/api/sastEvents.ts
+++ b/src/api/sastEvents.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { DataFrame, FieldType, TimeRange, createDataFrame } from '@grafana/data';
-import { FetchResponse } from '@grafana/runtime';
+import { FetchResponse, isFetchError } from '@grafana/runtime';
 import { SastEventsQueryOptions } from 'types';
 import { SastFinding } from './sastCommon';
 
@@ -254,6 +254,15 @@ const SastEventsApiResponseSchema = z.object({
 
 type SastEventsEvent = z.infer<typeof SastEventsEventSchema>;
 
+interface SastEventsApiRequest {
+  branch?: string;
+  githubRepositoryIds?: string;
+  fromTime?: string; // ISO string
+  fromEvent?: string;
+  numItems?: number; //max 100
+  sort?: "asc" | "desc";
+}
+
 export const processSastEvents = async (
   queryOptions: SastEventsQueryOptions,
   range: TimeRange,
@@ -262,26 +271,32 @@ export const processSastEvents = async (
   let events: SastEventsEvent[] = [];
   let prevEventId = null;
   for (let i = 0; i < MAX_API_REQUESTS; ++i) {
-    const params = {
-      ...(queryOptions.queryParameters.githubRepositoryId
-        ? { githubRepositoryId: queryOptions.queryParameters.githubRepositoryId }
+    const params: SastEventsApiRequest = {
+      ...(queryOptions.queryParameters.githubRepositoryIds
+        ? { githubRepositoryIds: queryOptions.queryParameters.githubRepositoryIds.join(',') }
         : {}),
-      ...(queryOptions.queryParameters.branch ? { severity: queryOptions.queryParameters.branch } : {}),
+      ...(queryOptions.queryParameters.branch ? { branch: queryOptions.queryParameters.branch } : {}),
       ...(queryOptions.queryParameters.eventTypes && queryOptions.queryParameters.eventTypes.length > 0
         ? { eventTypes: queryOptions.queryParameters.eventTypes.join(',') }
         : {}),
       ...(prevEventId ? { fromEvent: prevEventId } : { fromTime: range.from.toISOString() }),
       sort: 'asc',
     };
-
-    const response: any = await request_fn('sast/events', params);
+    const endpointPath = 'sast/events';
+    console.log(`[${endpointPath}] starting request with params:`, params);
+    const response: any = await request_fn(endpointPath, params);
 
     const parseResult = SastEventsApiResponseSchema.safeParse(response.data);
     if (!parseResult.success) {
-      console.error('Error in data from sast events API', parseResult.error);
-      console.log('sast events request:', params);
-      console.log('sast events response:', response);
-      throw new Error(`Data from the API is misformed. See console log for more details.`);
+      throw {
+        message: `Data from the API is misformed. Contact Nullify with the data below for help`,
+        data: {
+          endpoint: endpointPath,
+          request_params: params,
+          response: response,
+          data_validation_error: parseResult.error,
+        }
+      };
     }
 
     if (parseResult.data.events) {

--- a/src/api/sastSummary.ts
+++ b/src/api/sastSummary.ts
@@ -38,14 +38,18 @@ export const processSastSummary = async (
         request_params: params,
         response: response,
         data_validation_error: parseResult.error,
-      }
+      },
     };
   }
 
   return createDataFrame({
     refId: queryOptions.refId,
     fields: [
-      { name: 'id', type: FieldType.string, values: parseResult.data.vulnerabilities.map((vuln) => vuln.id) },
+      {
+        name: 'id',
+        type: FieldType.string,
+        values: parseResult.data.vulnerabilities.map((vuln) => vuln.id),
+      },
       {
         name: 'formatted_severity',
         type: FieldType.string,
@@ -56,7 +60,11 @@ export const processSastSummary = async (
         type: FieldType.string,
         values: parseResult.data.vulnerabilities.map((vuln) => vuln.severity),
       },
-      { name: 'cwe', type: FieldType.number, values: parseResult.data.vulnerabilities.map((vuln) => vuln.cwe) },
+      {
+        name: 'cwe',
+        type: FieldType.number,
+        values: parseResult.data.vulnerabilities.map((vuln) => vuln.cwe),
+      },
       {
         name: 'language',
         type: FieldType.string,

--- a/src/api/sastSummary.ts
+++ b/src/api/sastSummary.ts
@@ -11,7 +11,7 @@ const SastSummaryApiResponseSchema = z.object({
 });
 
 interface SastSummaryApiRequest {
-  githubRepositoryIds?: string;
+  githubRepositoryId?: number[];
   severity?: string;
 }
 
@@ -21,7 +21,7 @@ export const processSastSummary = async (
 ): Promise<DataFrame> => {
   const params: SastSummaryApiRequest = {
     ...(queryOptions.queryParameters.githubRepositoryIds
-      ? { githubRepositoryIds: queryOptions.queryParameters.githubRepositoryIds.join(',') }
+      ? { githubRepositoryId: queryOptions.queryParameters.githubRepositoryIds }
       : {}),
     ...(queryOptions.queryParameters.severity ? { severity: queryOptions.queryParameters.severity } : {}),
   };

--- a/src/api/sastSummary.ts
+++ b/src/api/sastSummary.ts
@@ -10,23 +10,36 @@ const SastSummaryApiResponseSchema = z.object({
   numItems: z.number(),
 });
 
+interface SastSummaryApiRequest {
+  githubRepositoryIds?: string;
+  severity?: string;
+}
+
 export const processSastSummary = async (
   queryOptions: SastSummaryQueryOptions,
   request_fn: (endpoint_path: string, params?: Record<string, any>) => Promise<FetchResponse<any>>
 ): Promise<DataFrame> => {
-  const response = await request_fn('sast/summary', {
-    ...(queryOptions.queryParameters.githubRepositoryId
-      ? { githubRepositoryId: queryOptions.queryParameters.githubRepositoryId }
+  const params: SastSummaryApiRequest = {
+    ...(queryOptions.queryParameters.githubRepositoryIds
+      ? { githubRepositoryIds: queryOptions.queryParameters.githubRepositoryIds.join(',') }
       : {}),
     ...(queryOptions.queryParameters.severity ? { severity: queryOptions.queryParameters.severity } : {}),
-  });
-  console.log('sast summary response:', response);
+  };
+  const endpointPath = 'sast/summary';
+  console.log(`[${endpointPath}] starting request with params:`, params);
+  const response = await request_fn(endpointPath, params);
 
   const parseResult = SastSummaryApiResponseSchema.safeParse(response.data);
   if (!parseResult.success) {
-    console.error('Error in data from sast summary API', parseResult.error);
-    console.log('SAST summary response:', response);
-    throw new Error(`Data from the API is misformed. See console log for more details.`);
+    throw {
+      message: `Data from the API is misformed. Contact Nullify with the data below for help`,
+      data: {
+        endpoint: endpointPath,
+        request_params: params,
+        response: response,
+        data_validation_error: parseResult.error,
+      }
+    };
   }
 
   return createDataFrame({

--- a/src/api/scaEvents.ts
+++ b/src/api/scaEvents.ts
@@ -210,7 +210,7 @@ interface ScaEventsApiRequest {
   fromTime?: string; // ISO string
   fromEvent?: string;
   numItems?: number; //max 100
-  sort?: "asc" | "desc";
+  sort?: 'asc' | 'desc';
 }
 
 export const processScaEvents = async (
@@ -245,7 +245,7 @@ export const processScaEvents = async (
           request_params: params,
           response: response,
           data_validation_error: parseResult.error,
-        }
+        },
       };
     }
 
@@ -268,13 +268,21 @@ export const processScaEvents = async (
   return createDataFrame({
     refId: queryOptions.refId,
     fields: [
-      { name: 'id', type: FieldType.string, values: events.map((event) => event.id) },
+      {
+        name: 'id',
+        type: FieldType.string,
+        values: events.map((event) => event.id),
+      },
       {
         name: 'time',
         type: FieldType.time,
         values: events.map((event) => new Date(event.timestampUnix * 1000)),
       },
-      { name: 'type', type: FieldType.string, values: events.map((event) => event.type) },
+      {
+        name: 'type',
+        type: FieldType.string,
+        values: events.map((event) => event.type),
+      },
       {
         name: 'numFindings',
         type: FieldType.number,

--- a/src/api/scaSummary.ts
+++ b/src/api/scaSummary.ts
@@ -3,6 +3,7 @@ import { DataFrame, FieldType, createDataFrame } from '@grafana/data';
 import { FetchResponse } from '@grafana/runtime';
 import { ScaSummaryQueryOptions } from 'types';
 import { ScaEventsDependencyFinding } from './scaCommon';
+import { unwrapRepositoryTemplateVariables } from 'utils/utils';
 
 const ScaSummaryApiResponseSchema = z.object({
   vulnerabilities: z.array(ScaEventsDependencyFinding).nullable(),
@@ -19,8 +20,12 @@ export const processScaSummary = async (
   request_fn: (endpoint_path: string, params?: Record<string, any>) => Promise<FetchResponse<any>>
 ): Promise<DataFrame> => {
   const params: ScaSummaryApiRequest = {
-    ...(queryOptions.queryParameters.githubRepositoryIds
-      ? { githubRepositoryId: queryOptions.queryParameters.githubRepositoryIds }
+    ...(queryOptions.queryParameters.githubRepositoryIdsOrQueries
+      ? {
+          githubRepositoryId: unwrapRepositoryTemplateVariables(
+            queryOptions.queryParameters.githubRepositoryIdsOrQueries
+          ),
+        }
       : {}),
     ...(queryOptions.queryParameters.package ? { package: queryOptions.queryParameters.package } : {}),
   };

--- a/src/api/scaSummary.ts
+++ b/src/api/scaSummary.ts
@@ -10,7 +10,7 @@ const ScaSummaryApiResponseSchema = z.object({
 });
 
 interface ScaSummaryApiRequest {
-  githubRepositoryIds?: string;
+  githubRepositoryId?: number[];
   severity?: string;
 }
 
@@ -20,7 +20,7 @@ export const processScaSummary = async (
 ): Promise<DataFrame> => {
   const params: ScaSummaryApiRequest = {
     ...(queryOptions.queryParameters.githubRepositoryIds
-      ? { githubRepositoryIds: queryOptions.queryParameters.githubRepositoryIds.join(',') }
+      ? { githubRepositoryId: queryOptions.queryParameters.githubRepositoryIds }
       : {}),
     ...(queryOptions.queryParameters.package ? { package: queryOptions.queryParameters.package } : {}),
   };

--- a/src/api/scaSummary.ts
+++ b/src/api/scaSummary.ts
@@ -37,14 +37,18 @@ export const processScaSummary = async (
         request_params: params,
         response: response,
         data_validation_error: parseResult.error,
-      }
+      },
     };
   }
 
   return createDataFrame({
     refId: queryOptions.refId,
     fields: [
-      { name: 'id', type: FieldType.string, values: parseResult.data.vulnerabilities?.map((vuln) => vuln.id) },
+      {
+        name: 'id',
+        type: FieldType.string,
+        values: parseResult.data.vulnerabilities?.map((vuln) => vuln.id),
+      },
       {
         name: 'isDirect',
         type: FieldType.string,

--- a/src/api/secretsEvents.ts
+++ b/src/api/secretsEvents.ts
@@ -90,12 +90,13 @@ const SecretsEventsApiResponseSchema = z.object({
 type SecretsEventsEvent = z.infer<typeof SecretsEventsEventSchema>;
 
 interface SecretsEventsApiRequest {
+  githubRepositoryId?: number[];
   branch?: string;
-  githubRepositoryIds?: string;
+  eventType?: string[];
   fromTime?: string; // ISO string
   fromEvent?: string;
   numItems?: number; //max 100
-  sort?: "asc" | "desc";
+  sort?: 'asc' | 'desc';
 }
 
 export const processSecretsEvents = async (
@@ -108,11 +109,11 @@ export const processSecretsEvents = async (
   for (let i = 0; i < MAX_API_REQUESTS; ++i) {
     const params: SecretsEventsApiRequest = {
       ...(queryOptions.queryParameters.githubRepositoryIds
-        ? { githubRepositoryIds: queryOptions.queryParameters.githubRepositoryIds.join(',') }
+        ? { githubRepositoryId: queryOptions.queryParameters.githubRepositoryIds }
         : {}),
-      ...(queryOptions.queryParameters.branch ? { severity: queryOptions.queryParameters.branch } : {}),
+      ...(queryOptions.queryParameters.branch ? { branch: queryOptions.queryParameters.branch } : {}),
       ...(queryOptions.queryParameters.eventTypes && queryOptions.queryParameters.eventTypes.length > 0
-        ? { eventTypes: queryOptions.queryParameters.eventTypes.join(',') }
+        ? { eventType: queryOptions.queryParameters.eventTypes }
         : {}),
       ...(prevEventId ? { fromEvent: prevEventId } : { fromTime: range.from.toISOString() }),
       sort: 'asc',

--- a/src/api/secretsSummary.ts
+++ b/src/api/secretsSummary.ts
@@ -50,21 +50,41 @@ export const processSecretsSummary = async (
   return createDataFrame({
     refId: queryOptions.refId,
     fields: [
-      { name: 'id', type: FieldType.string, values: parseResult.data.secrets?.map((secret) => secret.id) },
+      {
+        name: 'id',
+        type: FieldType.string,
+        values: parseResult.data.secrets?.map((secret) => secret.id),
+      },
       {
         name: 'secretType',
         type: FieldType.string,
         values: parseResult.data.secrets?.map((secret) => secret.secretType),
       },
-      { name: 'filePath', type: FieldType.string, values: parseResult.data.secrets?.map((secret) => secret.filePath) },
-      { name: 'author', type: FieldType.string, values: parseResult.data.secrets?.map((secret) => secret.author) },
+      {
+        name: 'filePath',
+        type: FieldType.string,
+        values: parseResult.data.secrets?.map((secret) => secret.filePath),
+      },
+      {
+        name: 'author',
+        type: FieldType.string,
+        values: parseResult.data.secrets?.map((secret) => secret.author),
+      },
       {
         name: 'timeStamp',
         type: FieldType.time,
         values: parseResult.data.secrets?.map((secret) => new Date(secret.timeStamp)),
       },
-      { name: 'ruleId', type: FieldType.string, values: parseResult.data.secrets?.map((secret) => secret.ruleId) },
-      { name: 'entropy', type: FieldType.number, values: parseResult.data.secrets?.map((secret) => secret.entropy) },
+      {
+        name: 'ruleId',
+        type: FieldType.string,
+        values: parseResult.data.secrets?.map((secret) => secret.ruleId),
+      },
+      {
+        name: 'entropy',
+        type: FieldType.number,
+        values: parseResult.data.secrets?.map((secret) => secret.entropy),
+      },
       {
         name: 'isBranchHead',
         type: FieldType.boolean,

--- a/src/api/secretsSummary.ts
+++ b/src/api/secretsSummary.ts
@@ -10,10 +10,10 @@ const SecretsSummaryApiResponseSchema = z.object({
 });
 
 interface SecretsSummaryApiRequest {
-  githubRepositoryIds?: string;
+  githubRepositoryId?: number[];
   branch?: string;
-  type?: string;
-  allowlisted?: boolean;
+  secretType?: string;
+  isAllowlisted?: boolean;
 }
 
 export const processSecretsSummary = async (
@@ -22,11 +22,11 @@ export const processSecretsSummary = async (
 ): Promise<DataFrame> => {
   const params: SecretsSummaryApiRequest = {
     ...(queryOptions.queryParameters.githubRepositoryIds
-      ? { githubRepositoryIds: queryOptions.queryParameters.githubRepositoryIds.join(',') }
+      ? { githubRepositoryId: queryOptions.queryParameters.githubRepositoryIds }
       : {}),
     ...(queryOptions.queryParameters.branch ? { branch: queryOptions.queryParameters.branch } : {}),
-    ...(queryOptions.queryParameters.type ? { type: queryOptions.queryParameters.type } : {}),
-    ...(queryOptions.queryParameters.allowlisted ? { allowlisted: queryOptions.queryParameters.allowlisted } : {}),
+    ...(queryOptions.queryParameters.secretType ? { secretType: queryOptions.queryParameters.secretType } : {}),
+    ...(queryOptions.queryParameters.isAllowlisted ? { isAllowlisted: queryOptions.queryParameters.isAllowlisted } : {}),
   };
   const endpointPath = 'secrets/summary';
   console.log(`[${endpointPath}] starting request with params:`, params);

--- a/src/components/Fields/RepositoryField.tsx
+++ b/src/components/Fields/RepositoryField.tsx
@@ -1,6 +1,7 @@
-import { SelectableValue } from '@grafana/data';
+import { SelectableValue, TypedVariableModel } from '@grafana/data';
+import { getTemplateSrv } from '@grafana/runtime';
 import { MultiSelect } from '@grafana/ui';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 export interface Repository {
   id: string;
@@ -9,30 +10,68 @@ export interface Repository {
 
 export interface RepositoryFieldProps {
   getRepositories: () => Promise<Repository[] | null>;
-  selectedRepositoryIds: number[];
-  setSelectedRepositoryIds: (selectedRepositories: number[]) => void;
+  selectedRepositoryIdsOrQueries: Array<number | string>;
+  setSelectedRepositoryIdsOrQueries: (selectedRepositories: Array<number | string>) => void;
 }
 
 export const RepositoryField = (props: RepositoryFieldProps) => {
-  const [selectedValues, setSelectedValues] = useState<Array<SelectableValue<number>>>([]);
+  const [selectedValues, setSelectedValues] = useState<Array<SelectableValue<number | string>>>(
+    props.selectedRepositoryIdsOrQueries.map((selected) => ({ label: selected.toString(), value: selected }))
+  );
   const [customOptions, setCustomOptions] = useState<Array<SelectableValue<number>>>([]);
-  const [allRepositoryOptions, setAllRepositoryOptions] = useState<Array<SelectableValue<number>> | undefined>(
+  const [allRepositoryOptions, setAllRepositoryOptions] = useState<Array<SelectableValue<number | string>> | undefined>(
     undefined
   );
 
+  const getRepositoriesRef = useRef(props.getRepositories);
+  const selectedRepositoryIdsOrQueriesRef = useRef(props.selectedRepositoryIdsOrQueries);
+
+  const onSelectedValuesChange = (newSelectedValues: Array<SelectableValue<number | string>>) => {
+    setSelectedValues(newSelectedValues);
+    const selectedRepositories = newSelectedValues
+      .map((selectable) => selectable.value)
+      .filter((repoIdOrQuery): repoIdOrQuery is string | number => repoIdOrQuery !== undefined);
+    props.setSelectedRepositoryIdsOrQueries(selectedRepositories);
+  };
+
   useEffect(() => {
-    props.getRepositories().then((repos) => {
-      if (repos) {
-        setAllRepositoryOptions(
-          repos.map((repo) => {
-            return { label: `${repo.name} (${repo.id})`, value: parseInt(repo.id, 10) };
-          })
-        );
-      } else {
+    const formatRepositorySelectableValue = (repo: Repository): SelectableValue<number> => {
+      return { label: `${repo.name} (${repo.id})`, value: Number(repo.id) };
+    };
+    const formatVariableSelectableValue = (variableName: string): SelectableValue<string> => {
+      return { label: `$${variableName}`, value: `$${variableName}` };
+    };
+
+    const variables: TypedVariableModel[] = getTemplateSrv().getVariables();
+
+    getRepositoriesRef
+      .current()
+      .then((repos) => {
+        if (repos) {
+          setAllRepositoryOptions([
+            ...variables.map((variable) => formatVariableSelectableValue(variable.id)),
+            ...repos.map(formatRepositorySelectableValue),
+          ]);
+          setSelectedValues([
+            ...variables
+              .map((variable) => formatVariableSelectableValue(variable.id))
+              .filter((selectableValue) =>
+                selectedRepositoryIdsOrQueriesRef.current.includes(selectableValue.value || '')
+              ),
+            ...repos
+              .map(formatRepositorySelectableValue)
+              .filter((selectableValue) =>
+                selectedRepositoryIdsOrQueriesRef.current.includes(selectableValue.value || '')
+              ),
+          ]);
+        } else {
+          setAllRepositoryOptions([]);
+        }
+      })
+      .catch(() => {
         setAllRepositoryOptions([]);
-      }
-    });
-  });
+      });
+  }, []);
 
   return (
     <>
@@ -44,17 +83,14 @@ export const RepositoryField = (props: RepositoryFieldProps) => {
         noOptionsMessage="No repositories found. To query a repository not listed, enter the repository ID."
         allowCustomValue
         value={selectedValues}
-        onChange={(values) => {
-          setSelectedValues(values);
-          props.setSelectedRepositoryIds(values.map((value) => value.value ?? -1));
-        }}
+        onChange={onSelectedValuesChange}
         isValidNewOption={(inputValue) => {
           return !isNaN(Number(inputValue));
         }}
         onCreateOption={(optionValue) => {
           const optionNumber = Number(optionValue);
           setCustomOptions([...customOptions, { value: optionNumber, label: `${optionNumber}` }]);
-          setSelectedValues([...selectedValues, { value: optionNumber, label: `${optionNumber}` }]);
+          onSelectedValuesChange([...selectedValues, { value: optionNumber, label: `${optionNumber}` }]);
         }}
       />
     </>

--- a/src/components/Fields/RepositoryField.tsx
+++ b/src/components/Fields/RepositoryField.tsx
@@ -1,0 +1,62 @@
+import { SelectableValue } from '@grafana/data';
+import { MultiSelect } from '@grafana/ui';
+import React, { useEffect, useState } from 'react';
+
+export interface Repository {
+  id: string;
+  name: string;
+}
+
+export interface RepositoryFieldProps {
+  getRepositories: () => Promise<Repository[] | null>;
+  selectedRepositoryIds: number[];
+  setSelectedRepositoryIds: (selectedRepositories: number[]) => void;
+}
+
+export const RepositoryField = (props: RepositoryFieldProps) => {
+  const [selectedValues, setSelectedValues] = useState<Array<SelectableValue<number>>>([]);
+  const [customOptions, setCustomOptions] = useState<Array<SelectableValue<number>>>([]);
+  const [allRepositoryOptions, setAllRepositoryOptions] = useState<Array<SelectableValue<number>> | undefined>(
+    undefined
+  );
+
+  useEffect(() => {
+    props.getRepositories().then((repos) => {
+      if (repos) {
+        setAllRepositoryOptions(
+          repos.map((repo) => {
+            return { label: `${repo.name} (${repo.id})`, value: parseInt(repo.id, 10) };
+          })
+        );
+      } else {
+        setAllRepositoryOptions([]);
+      }
+    });
+  });
+
+  return (
+    <>
+      <MultiSelect
+        options={[...(allRepositoryOptions ?? []), ...customOptions]}
+        isLoading={allRepositoryOptions === undefined}
+        closeMenuOnSelect={false}
+        placeholder="Select repositories or enter a repository ID"
+        noOptionsMessage="No repositories found. To query a repository not listed, enter the repository ID."
+        allowCustomValue
+        value={selectedValues}
+        onChange={(values) => {
+          setSelectedValues(values);
+          props.setSelectedRepositoryIds(values.map((value) => value.value ?? -1));
+        }}
+        isValidNewOption={(inputValue) => {
+          return !isNaN(Number(inputValue));
+        }}
+        onCreateOption={(optionValue) => {
+          const optionNumber = Number(optionValue);
+          setCustomOptions([...customOptions, { value: optionNumber, label: `${optionNumber}` }]);
+          setSelectedValues([...selectedValues, { value: optionNumber, label: `${optionNumber}` }]);
+        }}
+      />
+    </>
+  );
+};

--- a/src/components/Query/QueryEditor.tsx
+++ b/src/components/Query/QueryEditor.tsx
@@ -38,7 +38,8 @@ export function QueryEditor(props: Props) {
       <Field label="Data Type" description="Category of Nullify data to query for">
         <Select
           options={endpoint_options}
-          value={query.endpoint ?? endpoint_options[0].value}
+          value={query.endpoint ?? ""}
+          placeholder='Select a data type'
           onChange={(v) => onEndpointChange(v.value ?? 'sast/summary')}
         />
       </Field>

--- a/src/components/Query/SastEventsSubquery.tsx
+++ b/src/components/Query/SastEventsSubquery.tsx
@@ -1,8 +1,9 @@
-import React, { ChangeEvent, FormEvent } from 'react';
-import { Checkbox, Field, Input, Select, VerticalGroup } from '@grafana/ui';
+import React, { ChangeEvent, FormEvent, useState } from 'react';
+import { Checkbox, Field, Input, VerticalGroup } from '@grafana/ui';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { NullifyDataSource } from '../../datasource';
-import { NullifyDataSourceOptions, NullifyEndpointPaths, NullifyQueryOptions } from '../../types';
+import { NullifyDataSourceOptions, NullifyQueryOptions } from '../../types';
+import { RepositoryField } from 'components/Fields/RepositoryField';
 
 type Props = QueryEditorProps<NullifyDataSource, NullifyQueryOptions, NullifyDataSourceOptions>;
 
@@ -28,13 +29,16 @@ const SastEventTypeOptions: Array<SelectableValue<string>> = [
 
 export function SastEventsSubquery(props: Props) {
   const { query, onChange, onRunQuery } = props;
+  const [selectedRepositoryIds, setSelectedRepositoryIds] = useState<number[]>([]);
 
-  const onRepoIdChange = (event: ChangeEvent<HTMLInputElement>) => {
+  const onRepoIdsChange = (respositoryIds: number[]) => {
+    setSelectedRepositoryIds(respositoryIds);
     onChange({
       ...query,
       endpoint: 'sast/events',
-      queryParameters: { ...query.queryParameters, githubRepositoryId: event.target.value },
+      queryParameters: { ...query.queryParameters, githubRepositoryIds: respositoryIds },
     });
+    onRunQuery();
   };
 
   const onBranchChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -49,14 +53,13 @@ export function SastEventsSubquery(props: Props) {
   return query.endpoint === 'sast/events' ? (
     <>
       <Field
-        label="Repository ID Filter"
-        description="Query to filter for only the vulnerabilities from the specified GitHub repository ID. Leave blank to query for all repositories."
+        label="Repository Filter"
+        description="Query to filter for only the vulnerabilities from the specified repositories. Select one or more repositories or enter your repository ID(s) below."
       >
-        <Input
-          onChange={onRepoIdChange}
-          placeholder="1234"
-          onBlur={onRunQuery}
-          value={query.queryParameters?.githubRepositoryId || ''}
+        <RepositoryField
+          getRepositories={props.datasource.getRepositories.bind(props.datasource)}
+          selectedRepositoryIds={selectedRepositoryIds}
+          setSelectedRepositoryIds={onRepoIdsChange}
         />
       </Field>
       <Field label="Branch Filter" description="Query to filter for only the vulnerabilities in a selected branch.">

--- a/src/components/Query/SastEventsSubquery.tsx
+++ b/src/components/Query/SastEventsSubquery.tsx
@@ -29,14 +29,14 @@ const SastEventTypeOptions: Array<SelectableValue<string>> = [
 
 export function SastEventsSubquery(props: Props) {
   const { query, onChange, onRunQuery } = props;
-  const [selectedRepositoryIds, setSelectedRepositoryIds] = useState<number[]>([]);
+  const [selectedRepositories, setSelectedRepositories] = useState<Array<(number | string)>>(query.queryParameters?.githubRepositoryIdsOrQueries || []);
 
-  const onRepoIdsChange = (respositoryIds: number[]) => {
-    setSelectedRepositoryIds(respositoryIds);
+  const onRepositoriesChange = (repositories: Array<(number | string)>) => {
+    setSelectedRepositories(repositories);
     onChange({
       ...query,
       endpoint: 'sast/events',
-      queryParameters: { ...query.queryParameters, githubRepositoryIds: respositoryIds },
+      queryParameters: { ...query.queryParameters, githubRepositoryIdsOrQueries: repositories },
     });
     onRunQuery();
   };
@@ -58,8 +58,8 @@ export function SastEventsSubquery(props: Props) {
       >
         <RepositoryField
           getRepositories={props.datasource.getRepositories.bind(props.datasource)}
-          selectedRepositoryIds={selectedRepositoryIds}
-          setSelectedRepositoryIds={onRepoIdsChange}
+          selectedRepositoryIdsOrQueries={selectedRepositories}
+          setSelectedRepositoryIdsOrQueries={onRepositoriesChange}
         />
       </Field>
       <Field label="Branch Filter" description="Query to filter for only the vulnerabilities in a selected branch.">

--- a/src/components/Query/SastEventsSubquery.tsx
+++ b/src/components/Query/SastEventsSubquery.tsx
@@ -2,30 +2,14 @@ import React, { ChangeEvent, FormEvent, useState } from 'react';
 import { Checkbox, Field, Input, VerticalGroup } from '@grafana/ui';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { NullifyDataSource } from '../../datasource';
-import { NullifyDataSourceOptions, NullifyQueryOptions } from '../../types';
+import { NullifyDataSourceOptions, NullifyQueryOptions, SastEventTypeDescriptions } from '../../types';
 import { RepositoryField } from 'components/Fields/RepositoryField';
 
 type Props = QueryEditorProps<NullifyDataSource, NullifyQueryOptions, NullifyDataSourceOptions>;
 
-const SastEventTypeOptions: Array<SelectableValue<string>> = [
-  { value: 'new-branch-summary', label: 'New Branch Summary' },
-  { value: 'new-finding', label: 'New Finding' },
-  { value: 'new-findings', label: 'New Findings' },
-  { value: 'new-fix', label: 'New Fix' },
-  { value: 'new-fixes', label: 'New Fixes' },
-  { value: 'new-allowlisted-finding', label: 'New Allowlisted Finding' },
-  { value: 'new-allowlisted-findings', label: 'New Allowlisted Findings' },
-  { value: 'new-unallowlisted-finding', label: 'New Unallowlisted Finding' },
-  { value: 'new-unallowlisted-findings', label: 'New Unallowlisted Findings' },
-  { value: 'new-pull-request-finding', label: 'New Pull Request Finding' },
-  { value: 'new-pull-request-findings', label: 'New Pull Request Findings' },
-  { value: 'new-pull-request-fix', label: 'New Pull Request Fix' },
-  { value: 'new-pull-request-fixes', label: 'New Pull Request Fixes' },
-  { value: 'new-pull-request-allowlisted-finding', label: 'New Pull Request Allowlisted Finding' },
-  { value: 'new-pull-request-allowlisted-findings', label: 'New Pull Request Allowlisted Findings' },
-  { value: 'new-pull-request-unallowlisted-finding', label: 'New Pull Request Unallowlisted Finding' },
-  { value: 'new-pull-request-unallowlisted-findings', label: 'New Pull Request Unallowlisted Findings' },
-];
+const SastEventTypeOptions: Array<SelectableValue<string>> = Object.entries(SastEventTypeDescriptions).map(
+  ([value, label]) => ({ value, label })
+);
 
 export function SastEventsSubquery(props: Props) {
   const { query, onChange, onRunQuery } = props;

--- a/src/components/Query/SastSummarySubquery.tsx
+++ b/src/components/Query/SastSummarySubquery.tsx
@@ -1,8 +1,9 @@
-import React, { ChangeEvent } from 'react';
-import { Field, Input, Select } from '@grafana/ui';
+import React, { useState } from 'react';
+import { Field, Select } from '@grafana/ui';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { NullifyDataSource } from '../../datasource';
-import { NullifyDataSourceOptions, NullifyEndpointPaths, NullifyQueryOptions } from '../../types';
+import { NullifyDataSourceOptions, NullifyQueryOptions } from '../../types';
+import { RepositoryField } from 'components/Fields/RepositoryField';
 
 type Props = QueryEditorProps<NullifyDataSource, NullifyQueryOptions, NullifyDataSourceOptions>;
 
@@ -16,13 +17,16 @@ const severity_options: Array<SelectableValue<string>> = [
 
 export function SastSummarySubquery(props: Props) {
   const { query, onChange, onRunQuery } = props;
+  const [selectedRepositoryIds, setSelectedRepositoryIds] = useState<number[]>([]);
 
-  const onRepoIdChange = (event: ChangeEvent<HTMLInputElement>) => {
+  const onRepoIdsChange = (respositoryIds: number[]) => {
+    setSelectedRepositoryIds(respositoryIds);
     onChange({
       ...query,
       endpoint: 'sast/summary',
-      queryParameters: { ...query.queryParameters, githubRepositoryId: event.target.value },
+      queryParameters: { ...query.queryParameters, githubRepositoryIds: respositoryIds },
     });
+    onRunQuery();
   };
 
   const onSeverityChange = (new_severity: string) => {
@@ -37,14 +41,13 @@ export function SastSummarySubquery(props: Props) {
   return query.endpoint === 'sast/summary' ? (
     <>
       <Field
-        label="Repository ID Filter"
-        description="Query to filter for only the vulnerabilities from the specified GitHub repository ID. Leave blank to query for all repositories."
+        label="Repository Filter"
+        description="Query to filter for only the vulnerabilities from the specified repositories. Select one or more repositories or enter your repository ID(s) below."
       >
-        <Input
-          onChange={onRepoIdChange}
-          placeholder="1234"
-          onBlur={onRunQuery}
-          value={query.queryParameters?.githubRepositoryId || ''}
+        <RepositoryField
+          getRepositories={props.datasource.getRepositories.bind(props.datasource)}
+          selectedRepositoryIds={selectedRepositoryIds}
+          setSelectedRepositoryIds={onRepoIdsChange}
         />
       </Field>
       <Field

--- a/src/components/Query/SastSummarySubquery.tsx
+++ b/src/components/Query/SastSummarySubquery.tsx
@@ -17,14 +17,14 @@ const severity_options: Array<SelectableValue<string>> = [
 
 export function SastSummarySubquery(props: Props) {
   const { query, onChange, onRunQuery } = props;
-  const [selectedRepositoryIds, setSelectedRepositoryIds] = useState<number[]>([]);
+  const [selectedRepositories, setSelectedRepositories] = useState<Array<(number | string)>>(query.queryParameters?.githubRepositoryIdsOrQueries || []);
 
-  const onRepoIdsChange = (respositoryIds: number[]) => {
-    setSelectedRepositoryIds(respositoryIds);
+  const onRepositoriesChange = (repositories: Array<(number | string)>) => {
+    setSelectedRepositories(repositories);
     onChange({
       ...query,
       endpoint: 'sast/summary',
-      queryParameters: { ...query.queryParameters, githubRepositoryIds: respositoryIds },
+      queryParameters: { ...query.queryParameters, githubRepositoryIdsOrQueries: repositories },
     });
     onRunQuery();
   };
@@ -46,8 +46,8 @@ export function SastSummarySubquery(props: Props) {
       >
         <RepositoryField
           getRepositories={props.datasource.getRepositories.bind(props.datasource)}
-          selectedRepositoryIds={selectedRepositoryIds}
-          setSelectedRepositoryIds={onRepoIdsChange}
+          selectedRepositoryIdsOrQueries={selectedRepositories}
+          setSelectedRepositoryIdsOrQueries={onRepositoriesChange}
         />
       </Field>
       <Field

--- a/src/components/Query/ScaEventsSubquery.tsx
+++ b/src/components/Query/ScaEventsSubquery.tsx
@@ -1,25 +1,15 @@
 import React, { ChangeEvent, FormEvent, useState } from 'react';
-import { Checkbox, Field, Input, Select, VerticalGroup } from '@grafana/ui';
+import { Checkbox, Field, Input, VerticalGroup } from '@grafana/ui';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { NullifyDataSource } from '../../datasource';
-import { NullifyDataSourceOptions, NullifyEndpointPaths, NullifyQueryOptions } from '../../types';
+import { NullifyDataSourceOptions, NullifyQueryOptions, ScaEventTypeDescriptions } from '../../types';
 import { RepositoryField } from 'components/Fields/RepositoryField';
 
 type Props = QueryEditorProps<NullifyDataSource, NullifyQueryOptions, NullifyDataSourceOptions>;
 
-const ScaEventTypeOptions: Array<SelectableValue<string>> = [
-  { value: 'new-branch-summary', label: 'New Branch Summary' },
-  { value: 'new-finding', label: 'New Finding' },
-  { value: 'new-findings', label: 'New Findings' },
-  { value: 'new-fix', label: 'New Fix' },
-  { value: 'new-fixes', label: 'New Fixes' },
-  { value: 'new-allowlisted-finding', label: 'New Allowlisted Finding' },
-  { value: 'new-allowlisted-findings', label: 'New Allowlisted Findings' },
-  { value: 'new-pull-request-finding', label: 'New Pull Request Finding' },
-  { value: 'new-pull-request-findings', label: 'New Pull Request Findings' },
-  { value: 'new-pull-request-fix', label: 'New Pull Request Fix' },
-  { value: 'new-pull-request-fixes', label: 'New Pull Request Fixes' },
-];
+const ScaEventTypeOptions: Array<SelectableValue<string>> = Object.entries(ScaEventTypeDescriptions).map(
+  ([value, label]) => ({ value, label })
+);
 
 export function ScaEventsSubquery(props: Props) {
   const { query, onChange, onRunQuery } = props;

--- a/src/components/Query/ScaEventsSubquery.tsx
+++ b/src/components/Query/ScaEventsSubquery.tsx
@@ -23,14 +23,14 @@ const ScaEventTypeOptions: Array<SelectableValue<string>> = [
 
 export function ScaEventsSubquery(props: Props) {
   const { query, onChange, onRunQuery } = props;
-  const [selectedRepositoryIds, setSelectedRepositoryIds] = useState<number[]>([]);
+  const [selectedRepositories, setSelectedRepositories] = useState<Array<(number | string)>>(query.queryParameters?.githubRepositoryIdsOrQueries || []);
 
-  const onRepoIdsChange = (respositoryIds: number[]) => {
-    setSelectedRepositoryIds(respositoryIds);
+  const onRepositoriesChange = (repositories: Array<(number | string)>) => {
+    setSelectedRepositories(repositories);
     onChange({
       ...query,
       endpoint: 'sca/events',
-      queryParameters: { ...query.queryParameters, githubRepositoryIds: respositoryIds },
+      queryParameters: { ...query.queryParameters, githubRepositoryIdsOrQueries: repositories },
     });
     onRunQuery();
   };
@@ -52,8 +52,8 @@ export function ScaEventsSubquery(props: Props) {
       >
         <RepositoryField
           getRepositories={props.datasource.getRepositories.bind(props.datasource)}
-          selectedRepositoryIds={selectedRepositoryIds}
-          setSelectedRepositoryIds={onRepoIdsChange}
+          selectedRepositoryIdsOrQueries={selectedRepositories}
+          setSelectedRepositoryIdsOrQueries={onRepositoriesChange}
         />
       </Field>
       <Field label="Branch Filter" description="Query to filter for only the vulnerabilities in a selected branch.">

--- a/src/components/Query/ScaEventsSubquery.tsx
+++ b/src/components/Query/ScaEventsSubquery.tsx
@@ -1,8 +1,9 @@
-import React, { ChangeEvent, FormEvent } from 'react';
+import React, { ChangeEvent, FormEvent, useState } from 'react';
 import { Checkbox, Field, Input, Select, VerticalGroup } from '@grafana/ui';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { NullifyDataSource } from '../../datasource';
 import { NullifyDataSourceOptions, NullifyEndpointPaths, NullifyQueryOptions } from '../../types';
+import { RepositoryField } from 'components/Fields/RepositoryField';
 
 type Props = QueryEditorProps<NullifyDataSource, NullifyQueryOptions, NullifyDataSourceOptions>;
 
@@ -22,13 +23,16 @@ const ScaEventTypeOptions: Array<SelectableValue<string>> = [
 
 export function ScaEventsSubquery(props: Props) {
   const { query, onChange, onRunQuery } = props;
+  const [selectedRepositoryIds, setSelectedRepositoryIds] = useState<number[]>([]);
 
-  const onRepoIdChange = (event: ChangeEvent<HTMLInputElement>) => {
+  const onRepoIdsChange = (respositoryIds: number[]) => {
+    setSelectedRepositoryIds(respositoryIds);
     onChange({
       ...query,
       endpoint: 'sca/events',
-      queryParameters: { ...query.queryParameters, githubRepositoryId: event.target.value },
+      queryParameters: { ...query.queryParameters, githubRepositoryIds: respositoryIds },
     });
+    onRunQuery();
   };
 
   const onBranchChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -43,14 +47,13 @@ export function ScaEventsSubquery(props: Props) {
   return query.endpoint === 'sca/events' ? (
     <>
       <Field
-        label="Repository ID Filter"
-        description="Query to filter for only the vulnerabilities from the specified GitHub repository ID. Leave blank to query for all repositories."
+        label="Repository Filter"
+        description="Query to filter for only the vulnerabilities from the specified repositories. Select one or more repositories or enter your repository ID(s) below."
       >
-        <Input
-          onChange={onRepoIdChange}
-          placeholder="1234"
-          onBlur={onRunQuery}
-          value={query.queryParameters?.githubRepositoryId || ''}
+        <RepositoryField
+          getRepositories={props.datasource.getRepositories.bind(props.datasource)}
+          selectedRepositoryIds={selectedRepositoryIds}
+          setSelectedRepositoryIds={onRepoIdsChange}
         />
       </Field>
       <Field label="Branch Filter" description="Query to filter for only the vulnerabilities in a selected branch.">

--- a/src/components/Query/ScaSummarySubquery.tsx
+++ b/src/components/Query/ScaSummarySubquery.tsx
@@ -1,20 +1,24 @@
-import React, { ChangeEvent } from 'react';
+import React, { ChangeEvent, useState } from 'react';
 import { Field, Input } from '@grafana/ui';
 import { QueryEditorProps } from '@grafana/data';
 import { NullifyDataSource } from '../../datasource';
 import { NullifyDataSourceOptions, NullifyQueryOptions } from '../../types';
+import { RepositoryField } from 'components/Fields/RepositoryField';
 
 type Props = QueryEditorProps<NullifyDataSource, NullifyQueryOptions, NullifyDataSourceOptions>;
 
 export function ScaSummarySubquery(props: Props) {
   const { query, onChange, onRunQuery } = props;
+  const [selectedRepositoryIds, setSelectedRepositoryIds] = useState<number[]>([]);
 
-  const onRepoIdChange = (event: ChangeEvent<HTMLInputElement>) => {
+  const onRepoIdsChange = (respositoryIds: number[]) => {
+    setSelectedRepositoryIds(respositoryIds);
     onChange({
       ...query,
       endpoint: 'sca/summary',
-      queryParameters: { ...query.queryParameters, githubRepositoryId: event.target.value },
+      queryParameters: { ...query.queryParameters, githubRepositoryIds: respositoryIds },
     });
+    onRunQuery();
   };
 
   const onPackageChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -28,14 +32,13 @@ export function ScaSummarySubquery(props: Props) {
   return query.endpoint === 'sca/summary' ? (
     <>
       <Field
-        label="Repository ID Filter"
-        description="Query to filter for only the vulnerabilities from the specified GitHub repository ID. Leave blank to query for all repositories."
+        label="Repository Filter"
+        description="Query to filter for only the vulnerabilities from the specified repositories. Select one or more repositories or enter your repository ID(s) below."
       >
-        <Input
-          onChange={onRepoIdChange}
-          placeholder="1234"
-          onBlur={onRunQuery}
-          value={query.queryParameters?.githubRepositoryId || ''}
+        <RepositoryField
+          getRepositories={props.datasource.getRepositories.bind(props.datasource)}
+          selectedRepositoryIds={selectedRepositoryIds}
+          setSelectedRepositoryIds={onRepoIdsChange}
         />
       </Field>
       <Field label="Package Filter" description="Query to filter for only the specified package.">

--- a/src/components/Query/ScaSummarySubquery.tsx
+++ b/src/components/Query/ScaSummarySubquery.tsx
@@ -9,14 +9,14 @@ type Props = QueryEditorProps<NullifyDataSource, NullifyQueryOptions, NullifyDat
 
 export function ScaSummarySubquery(props: Props) {
   const { query, onChange, onRunQuery } = props;
-  const [selectedRepositoryIds, setSelectedRepositoryIds] = useState<number[]>([]);
+  const [selectedRepositories, setSelectedRepositories] = useState<Array<(number | string)>>(query.queryParameters?.githubRepositoryIdsOrQueries || []);
 
-  const onRepoIdsChange = (respositoryIds: number[]) => {
-    setSelectedRepositoryIds(respositoryIds);
+  const onRepositoriesChange = (repositories: Array<(number | string)>) => {
+    setSelectedRepositories(repositories);
     onChange({
       ...query,
       endpoint: 'sca/summary',
-      queryParameters: { ...query.queryParameters, githubRepositoryIds: respositoryIds },
+      queryParameters: { ...query.queryParameters, githubRepositoryIdsOrQueries: repositories },
     });
     onRunQuery();
   };
@@ -37,8 +37,8 @@ export function ScaSummarySubquery(props: Props) {
       >
         <RepositoryField
           getRepositories={props.datasource.getRepositories.bind(props.datasource)}
-          selectedRepositoryIds={selectedRepositoryIds}
-          setSelectedRepositoryIds={onRepoIdsChange}
+          selectedRepositoryIdsOrQueries={selectedRepositories}
+          setSelectedRepositoryIdsOrQueries={onRepositoriesChange}
         />
       </Field>
       <Field label="Package Filter" description="Query to filter for only the specified package.">

--- a/src/components/Query/SecretsEventsSubquery.tsx
+++ b/src/components/Query/SecretsEventsSubquery.tsx
@@ -18,12 +18,12 @@ export function SecretsEventsSubquery(props: Props) {
   const { query, onChange, onRunQuery } = props;
   const [selectedRepositoryIds, setSelectedRepositoryIds] = useState<number[]>([]);
 
-  const onRepoIdsChange = (respositoryIds: number[]) => {
-    setSelectedRepositoryIds(respositoryIds);
+  const onRepoIdsChange = (repositoryIds: number[]) => {
+    setSelectedRepositoryIds(repositoryIds);
     onChange({
       ...query,
       endpoint: 'secrets/events',
-      queryParameters: { ...query.queryParameters, githubRepositoryIds: respositoryIds },
+      queryParameters: { ...query.queryParameters, githubRepositoryIds: repositoryIds },
     });
     onRunQuery();
   };

--- a/src/components/Query/SecretsEventsSubquery.tsx
+++ b/src/components/Query/SecretsEventsSubquery.tsx
@@ -16,14 +16,14 @@ const SecretsEventTypeOptions: Array<SelectableValue<string>> = [
 
 export function SecretsEventsSubquery(props: Props) {
   const { query, onChange, onRunQuery } = props;
-  const [selectedRepositoryIds, setSelectedRepositoryIds] = useState<number[]>([]);
+  const [selectedRepositories, setSelectedRepositories] = useState<Array<(number | string)>>(query.queryParameters?.githubRepositoryIdsOrQueries || []);
 
-  const onRepoIdsChange = (repositoryIds: number[]) => {
-    setSelectedRepositoryIds(repositoryIds);
+  const onRepositoriesChange = (repositories: Array<(number | string)>) => {
+    setSelectedRepositories(repositories);
     onChange({
       ...query,
       endpoint: 'secrets/events',
-      queryParameters: { ...query.queryParameters, githubRepositoryIds: repositoryIds },
+      queryParameters: { ...query.queryParameters, githubRepositoryIdsOrQueries: repositories },
     });
     onRunQuery();
   };
@@ -45,8 +45,8 @@ export function SecretsEventsSubquery(props: Props) {
       >
         <RepositoryField
           getRepositories={props.datasource.getRepositories.bind(props.datasource)}
-          selectedRepositoryIds={selectedRepositoryIds}
-          setSelectedRepositoryIds={onRepoIdsChange}
+          selectedRepositoryIdsOrQueries={selectedRepositories}
+          setSelectedRepositoryIdsOrQueries={onRepositoriesChange}
         />
       </Field>
       <Field label="Branch Filter" description="Query to filter for only the secrets in a selected branch.">

--- a/src/components/Query/SecretsEventsSubquery.tsx
+++ b/src/components/Query/SecretsEventsSubquery.tsx
@@ -2,17 +2,14 @@ import React, { ChangeEvent, FormEvent, useState } from 'react';
 import { Checkbox, Field, Input, VerticalGroup } from '@grafana/ui';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { NullifyDataSource } from '../../datasource';
-import { NullifyDataSourceOptions, NullifyQueryOptions } from '../../types';
+import { NullifyDataSourceOptions, NullifyQueryOptions, SecretsEventTypeDescriptions } from '../../types';
 import { RepositoryField } from 'components/Fields/RepositoryField';
 
 type Props = QueryEditorProps<NullifyDataSource, NullifyQueryOptions, NullifyDataSourceOptions>;
 
-const SecretsEventTypeOptions: Array<SelectableValue<string>> = [
-  { value: 'new-finding', label: 'New Finding' },
-  { value: 'new-findings', label: 'New Findings' },
-  { value: 'new-allowlisted-finding', label: 'New Allowlisted Finding' },
-  { value: 'new-allowlisted-findings', label: 'New Allowlisted Findings' },
-];
+const SecretsEventTypeOptions: Array<SelectableValue<string>> = Object.entries(SecretsEventTypeDescriptions).map(
+  ([value, label]) => ({ value, label })
+);
 
 export function SecretsEventsSubquery(props: Props) {
   const { query, onChange, onRunQuery } = props;

--- a/src/components/Query/SecretsEventsSubquery.tsx
+++ b/src/components/Query/SecretsEventsSubquery.tsx
@@ -1,8 +1,9 @@
-import React, { ChangeEvent, FormEvent } from 'react';
-import { Checkbox, Field, Input, Select, VerticalGroup } from '@grafana/ui';
+import React, { ChangeEvent, FormEvent, useState } from 'react';
+import { Checkbox, Field, Input, VerticalGroup } from '@grafana/ui';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { NullifyDataSource } from '../../datasource';
-import { NullifyDataSourceOptions, NullifyEndpointPaths, NullifyQueryOptions } from '../../types';
+import { NullifyDataSourceOptions, NullifyQueryOptions } from '../../types';
+import { RepositoryField } from 'components/Fields/RepositoryField';
 
 type Props = QueryEditorProps<NullifyDataSource, NullifyQueryOptions, NullifyDataSourceOptions>;
 
@@ -15,13 +16,16 @@ const SecretsEventTypeOptions: Array<SelectableValue<string>> = [
 
 export function SecretsEventsSubquery(props: Props) {
   const { query, onChange, onRunQuery } = props;
+  const [selectedRepositoryIds, setSelectedRepositoryIds] = useState<number[]>([]);
 
-  const onRepoIdChange = (event: ChangeEvent<HTMLInputElement>) => {
+  const onRepoIdsChange = (respositoryIds: number[]) => {
+    setSelectedRepositoryIds(respositoryIds);
     onChange({
       ...query,
       endpoint: 'secrets/events',
-      queryParameters: { ...query.queryParameters, githubRepositoryId: event.target.value },
+      queryParameters: { ...query.queryParameters, githubRepositoryIds: respositoryIds },
     });
+    onRunQuery();
   };
 
   const onBranchChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -36,14 +40,13 @@ export function SecretsEventsSubquery(props: Props) {
   return query.endpoint === 'secrets/events' ? (
     <>
       <Field
-        label="Repository ID Filter"
-        description="Query to filter for only the secrets from the specified GitHub repository ID. Leave blank to query for all repositories."
+        label="Repository Filter"
+        description="Query to filter for only the vulnerabilities from the specified repositories. Select one or more repositories or enter your repository ID(s) below."
       >
-        <Input
-          onChange={onRepoIdChange}
-          placeholder="1234"
-          onBlur={onRunQuery}
-          value={query.queryParameters?.githubRepositoryId || ''}
+        <RepositoryField
+          getRepositories={props.datasource.getRepositories.bind(props.datasource)}
+          selectedRepositoryIds={selectedRepositoryIds}
+          setSelectedRepositoryIds={onRepoIdsChange}
         />
       </Field>
       <Field label="Branch Filter" description="Query to filter for only the secrets in a selected branch.">

--- a/src/components/Query/SecretsSummarySubquery.tsx
+++ b/src/components/Query/SecretsSummarySubquery.tsx
@@ -29,11 +29,11 @@ export function SecretsSummarySubquery(props: Props) {
     });
   };
 
-  const onTypeChange = (event: ChangeEvent<HTMLInputElement>) => {
+  const onSecretTypeChange = (event: ChangeEvent<HTMLInputElement>) => {
     onChange({
       ...query,
       endpoint: 'secrets/summary',
-      queryParameters: { ...query.queryParameters, type: event.target.value },
+      queryParameters: { ...query.queryParameters, secretType: event.target.value },
     });
   };
 
@@ -41,7 +41,7 @@ export function SecretsSummarySubquery(props: Props) {
     onChange({
       ...query,
       endpoint: 'secrets/summary',
-      queryParameters: { ...query.queryParameters, allowlisted: event.target.checked },
+      queryParameters: { ...query.queryParameters, isAllowlisted: event.target.checked },
     });
   };
 
@@ -65,17 +65,17 @@ export function SecretsSummarySubquery(props: Props) {
           value={query.queryParameters?.branch || ''}
         />
       </Field>
-      <Field label="Type Filter" description="Query to filter for only the specified type.">
+      <Field label="Secret Type Filter" description="Query to filter for only the specified type.">
         <Input
-          onChange={onTypeChange}
-          placeholder="new-finding"
+          onChange={onSecretTypeChange}
+          placeholder="generic-api-key"
           onBlur={onRunQuery}
-          value={query.queryParameters?.type || ''}
+          value={query.queryParameters?.secretType || ''}
         />
       </Field>
 
       <Field label="Include allowlisted secrets?" description="Query to filter include/exclude allowlisted secrets. Default: enabled">
-        <Switch value={query.queryParameters.allowlisted ?? true} onChange={onAllowlistedChange} />
+        <Switch value={query.queryParameters.isAllowlisted ?? true} onChange={onAllowlistedChange} />
       </Field>
     </>
   ) : (

--- a/src/components/Query/SecretsSummarySubquery.tsx
+++ b/src/components/Query/SecretsSummarySubquery.tsx
@@ -9,14 +9,14 @@ type Props = QueryEditorProps<NullifyDataSource, NullifyQueryOptions, NullifyDat
 
 export function SecretsSummarySubquery(props: Props) {
   const { query, onChange, onRunQuery } = props;
-  const [selectedRepositoryIds, setSelectedRepositoryIds] = useState<number[]>([]);
+  const [selectedRepositories, setSelectedRepositories] = useState<Array<(number | string)>>(query.queryParameters?.githubRepositoryIdsOrQueries || []);
 
-  const onRepoIdsChange = (respositoryIds: number[]) => {
-    setSelectedRepositoryIds(respositoryIds);
+  const onRepositoriesChange = (repositories: Array<(number | string)>) => {
+    setSelectedRepositories(repositories);
     onChange({
       ...query,
       endpoint: 'secrets/summary',
-      queryParameters: { ...query.queryParameters, githubRepositoryIds: respositoryIds },
+      queryParameters: { ...query.queryParameters, githubRepositoryIdsOrQueries: repositories },
     });
     onRunQuery();
   };
@@ -53,8 +53,8 @@ export function SecretsSummarySubquery(props: Props) {
       >
         <RepositoryField
           getRepositories={props.datasource.getRepositories.bind(props.datasource)}
-          selectedRepositoryIds={selectedRepositoryIds}
-          setSelectedRepositoryIds={onRepoIdsChange}
+          selectedRepositoryIdsOrQueries={selectedRepositories}
+          setSelectedRepositoryIdsOrQueries={onRepositoriesChange}
         />
       </Field>
       <Field label="Branch Filter" description="Query to filter for only the specified branch.">

--- a/src/components/Query/SecretsSummarySubquery.tsx
+++ b/src/components/Query/SecretsSummarySubquery.tsx
@@ -1,20 +1,24 @@
-import React, { ChangeEvent } from 'react';
+import React, { ChangeEvent, useState } from 'react';
 import { Field, Input, Switch } from '@grafana/ui';
 import { QueryEditorProps } from '@grafana/data';
 import { NullifyDataSource } from '../../datasource';
 import { NullifyDataSourceOptions, NullifyQueryOptions } from '../../types';
+import { RepositoryField } from 'components/Fields/RepositoryField';
 
 type Props = QueryEditorProps<NullifyDataSource, NullifyQueryOptions, NullifyDataSourceOptions>;
 
 export function SecretsSummarySubquery(props: Props) {
   const { query, onChange, onRunQuery } = props;
+  const [selectedRepositoryIds, setSelectedRepositoryIds] = useState<number[]>([]);
 
-  const onRepoIdChange = (event: ChangeEvent<HTMLInputElement>) => {
+  const onRepoIdsChange = (respositoryIds: number[]) => {
+    setSelectedRepositoryIds(respositoryIds);
     onChange({
       ...query,
       endpoint: 'secrets/summary',
-      queryParameters: { ...query.queryParameters, githubRepositoryId: event.target.value },
+      queryParameters: { ...query.queryParameters, githubRepositoryIds: respositoryIds },
     });
+    onRunQuery();
   };
 
   const onBranchChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -44,14 +48,13 @@ export function SecretsSummarySubquery(props: Props) {
   return query.endpoint === 'secrets/summary' ? (
     <>
       <Field
-        label="Repository ID Filter"
-        description="Query to filter for only the secrets from the specified GitHub repository ID. Leave blank to query for all repositories."
+        label="Repository Filter"
+        description="Query to filter for only the vulnerabilities from the specified repositories. Select one or more repositories or enter your repository ID(s) below."
       >
-        <Input
-          onChange={onRepoIdChange}
-          placeholder="1234"
-          onBlur={onRunQuery}
-          value={query.queryParameters?.githubRepositoryId || ''}
+        <RepositoryField
+          getRepositories={props.datasource.getRepositories.bind(props.datasource)}
+          selectedRepositoryIds={selectedRepositoryIds}
+          setSelectedRepositoryIds={onRepoIdsChange}
         />
       </Field>
       <Field label="Branch Filter" description="Query to filter for only the specified branch.">

--- a/src/components/VariableQueryEditor.tsx
+++ b/src/components/VariableQueryEditor.tsx
@@ -1,0 +1,20 @@
+import React, { useEffect, useState } from 'react';
+import { NullifyVariableQuery, VariableQueryType } from '../types';
+
+interface VariableQueryProps {
+  query: NullifyVariableQuery;
+  onChange: (query: NullifyVariableQuery, definition: string) => void;
+}
+
+export const VariableQueryEditor = ({ onChange, query }: VariableQueryProps) => {
+  useEffect(() => {
+    onChange({ queryType: VariableQueryType.Repository }, `Nullify ${VariableQueryType.Repository} Query`);
+  }, [onChange]);
+
+  return (
+    <>
+      This query variable enables the creation of a dashboard-wide filter for repositories.
+      {/* ADD SELECTOR FOR OTHER QUERY TYPES (e.g. Repo/Branch/Team) */}
+    </>
+  );
+};

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -35,10 +35,12 @@ export class NullifyDataSource extends DataSourceApi<NullifyQueryOptions, Nullif
   async getRepositories() {
     const response = await this._request('admin/repositories');
     const AdminRepositoriesSchema = z.object({
-      repositories: z.array(z.object({
-        id: z.string(),
-        name: z.string(),
-      })),
+      repositories: z.array(
+        z.object({
+          id: z.string(),
+          name: z.string(),
+        })
+      ),
     });
 
     let result = AdminRepositoriesSchema.safeParse(response.data);
@@ -115,14 +117,20 @@ export class NullifyDataSource extends DataSourceApi<NullifyQueryOptions, Nullif
       processSecretsSummary(
         { refId: 'test', endpoint: 'secrets/summary', queryParameters: {} },
         this._request.bind(this)
-      ).catch((err) => ({ status: 'error', message: `Error in Secrets Summary: ${JSON.stringify(err.message ?? err)}` })),
+      ).catch((err) => ({
+        status: 'error',
+        message: `Error in Secrets Summary: ${JSON.stringify(err.message ?? err)}`,
+      })),
       processSecretsEvents(
         { refId: 'test', endpoint: 'secrets/events', queryParameters: {} },
         testTimeRange,
         this._request.bind(this)
-      ).catch((err) => ({ status: 'error', message: `Error in Secrets Events: ${JSON.stringify(err.message ?? err)}` })),
+      ).catch((err) => ({
+        status: 'error',
+        message: `Error in Secrets Events: ${JSON.stringify(err.message ?? err)}`,
+      })),
     ];
-  
+
     const results = await Promise.allSettled(promises);
     const err: string[] = [];
 
@@ -137,7 +145,7 @@ export class NullifyDataSource extends DataSourceApi<NullifyQueryOptions, Nullif
         err.push(result.value.message);
       }
     });
-    
+
     if (err.length > 0) {
       console.error('Test failed', err.join('\n'));
       return {

--- a/src/module.ts
+++ b/src/module.ts
@@ -3,6 +3,7 @@ import { NullifyDataSource } from './datasource';
 import { ConfigEditor } from './components/ConfigEditor';
 import { QueryEditor } from './components/Query/QueryEditor';
 import { NullifyDataSourceOptions, NullifyQueryOptions } from './types';
+import { VariableQueryEditor } from 'components/VariableQueryEditor';
 
 export const plugin = new DataSourcePlugin<
   NullifyDataSource,
@@ -10,4 +11,5 @@ export const plugin = new DataSourcePlugin<
   NullifyDataSourceOptions
 >(NullifyDataSource)
   .setConfigEditor(ConfigEditor)
-  .setQueryEditor(QueryEditor);
+  .setQueryEditor(QueryEditor)
+  .setVariableQueryEditor(VariableQueryEditor);

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,14 @@ export interface NullifySecureJsonData {
   apiKey?: string;
 }
 
+export enum VariableQueryType {
+  Repository = 'Repository',
+}
+
+export interface NullifyVariableQuery {
+  queryType: VariableQueryType;
+}
+
 export type NullifyEndpointPaths =
   | 'sast/summary'
   | 'sast/events'
@@ -35,7 +43,7 @@ export interface SastSummaryQueryOptions extends BaseQueryOptions {
 }
 
 export interface SastSummaryQueryParameters {
-  githubRepositoryIds?: number[];
+  githubRepositoryIdsOrQueries?: Array<number | string>;
   severity?: string;
 }
 
@@ -47,7 +55,7 @@ export interface SastEventsQueryOptions extends BaseQueryOptions {
 }
 
 export interface SastEventsQueryParameters {
-  githubRepositoryIds?: number[];
+  githubRepositoryIdsOrQueries?: Array<number | string>;
   branch?: string;
   eventTypes?: string[];
 }
@@ -60,7 +68,7 @@ export interface ScaSummaryQueryOptions extends BaseQueryOptions {
 }
 
 export interface ScaSummaryQueryParameters {
-  githubRepositoryIds?: number[];
+  githubRepositoryIdsOrQueries?: Array<number | string>;
   package?: string;
 }
 
@@ -72,7 +80,7 @@ export interface ScaEventsQueryOptions extends BaseQueryOptions {
 }
 
 export interface ScaEventsQueryParameters {
-  githubRepositoryIds?: number[];
+  githubRepositoryIdsOrQueries?: Array<number | string>;
   branch?: string;
   eventTypes?: string[];
 }
@@ -85,7 +93,7 @@ export interface SecretsSummaryQueryOptions extends BaseQueryOptions {
 }
 
 export interface SecretsSummaryQueryParameters {
-  githubRepositoryIds?: number[];
+  githubRepositoryIdsOrQueries?: Array<number | string>;
   branch?: string;
   secretType?: string;
   isAllowlisted?: boolean;
@@ -99,7 +107,7 @@ export interface SecretsEventsQueryOptions extends BaseQueryOptions {
 }
 
 export interface SecretsEventsQueryParameters {
-  githubRepositoryIds?: number[];
+  githubRepositoryIdsOrQueries?: Array<number | string>;
   branch?: string;
   eventTypes?: string[];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,46 @@ export interface SastEventsQueryParameters {
   eventTypes?: string[];
 }
 
+export enum SastEventType {
+  NewBranchSummary = 'new-branch-summary',
+  NewFinding = 'new-finding',
+  NewFindings = 'new-findings',
+  NewFix = 'new-fix',
+  NewFixes = 'new-fixes',
+  NewAllowlistedFinding = 'new-allowlisted-finding',
+  NewAllowlistedFindings = 'new-allowlisted-findings',
+  NewUnallowlistedFinding = 'new-unallowlisted-finding',
+  NewUnallowlistedFindings = 'new-unallowlisted-findings',
+  NewPullRequestFinding = 'new-pull-request-finding',
+  NewPullRequestFindings = 'new-pull-request-findings',
+  NewPullRequestFix = 'new-pull-request-fix',
+  NewPullRequestFixes = 'new-pull-request-fixes',
+  NewPullRequestAllowlistedFinding = 'new-pull-request-allowlisted-finding',
+  NewPullRequestAllowlistedFindings = 'new-pull-request-allowlisted-findings',
+  NewPullRequestUnallowlistedFinding = 'new-pull-request-unallowlisted-finding',
+  NewPullRequestUnallowlistedFindings = 'new-pull-request-unallowlisted-findings',
+}
+
+export const SastEventTypeDescriptions: Record<SastEventType, string> = {
+  [SastEventType.NewBranchSummary]: 'New Branch Summary',
+  [SastEventType.NewFinding]: 'New Finding',
+  [SastEventType.NewFindings]: 'New Findings',
+  [SastEventType.NewFix]: 'New Fix',
+  [SastEventType.NewFixes]: 'New Fixes',
+  [SastEventType.NewAllowlistedFinding]: 'New Allowlisted Finding',
+  [SastEventType.NewAllowlistedFindings]: 'New Allowlisted Findings',
+  [SastEventType.NewUnallowlistedFinding]: 'New Unallowlisted Finding',
+  [SastEventType.NewUnallowlistedFindings]: 'New Unallowlisted Findings',
+  [SastEventType.NewPullRequestFinding]: 'New Pull Request Finding',
+  [SastEventType.NewPullRequestFindings]: 'New Pull Request Findings',
+  [SastEventType.NewPullRequestFix]: 'New Pull Request Fix',
+  [SastEventType.NewPullRequestFixes]: 'New Pull Request Fixes',
+  [SastEventType.NewPullRequestAllowlistedFinding]: 'New Pull Request Allowlisted Finding',
+  [SastEventType.NewPullRequestAllowlistedFindings]: 'New Pull Request Allowlisted Findings',
+  [SastEventType.NewPullRequestUnallowlistedFinding]: 'New Pull Request Unallowlisted Finding',
+  [SastEventType.NewPullRequestUnallowlistedFindings]: 'New Pull Request Unallowlisted Findings',
+};
+
 // SCA SUMMARY ENDPOINT
 
 export interface ScaSummaryQueryOptions extends BaseQueryOptions {
@@ -84,6 +124,38 @@ export interface ScaEventsQueryParameters {
   branch?: string;
   eventTypes?: string[];
 }
+
+export enum ScaEventType {
+  NewBranchSummary = 'new-branch-summary',
+  NewFinding = 'new-finding',
+  NewFindings = 'new-findings',
+  NewAllowlistedFinding = 'new-allowlisted-finding',
+  NewAllowlistedFindings = 'new-allowlisted-findings',
+  NewFix = 'new-fix',
+  NewFixes = 'new-fixes',
+  NewPullRequestFinding = 'new-pull-request-finding',
+  NewPullRequestFindings = 'new-pull-request-findings',
+  NewPullRequestFix = 'new-pull-request-fix',
+  NewPullRequestFixes = 'new-pull-request-fixes',
+  BotInteractionPR = 'bot-interaction-pr',
+  BotInteractionIssue = 'bot-interaction-issue',
+}
+
+export const ScaEventTypeDescriptions: Record<ScaEventType, string> = {
+  [ScaEventType.NewBranchSummary]: 'New Branch Summary',
+  [ScaEventType.NewFinding]: 'New Finding',
+  [ScaEventType.NewFindings]: 'New Findings',
+  [ScaEventType.NewAllowlistedFinding]: 'New Allowlisted Finding',
+  [ScaEventType.NewAllowlistedFindings]: 'New Allowlisted Findings',
+  [ScaEventType.NewFix]: 'New Fix',
+  [ScaEventType.NewFixes]: 'New Fixes',
+  [ScaEventType.NewPullRequestFinding]: 'New Pull Request Finding',
+  [ScaEventType.NewPullRequestFindings]: 'New Pull Request Findings',
+  [ScaEventType.NewPullRequestFix]: 'New Pull Request Fix',
+  [ScaEventType.NewPullRequestFixes]: 'New Pull Request Fixes',
+  [ScaEventType.BotInteractionPR]: 'Bot Interaction PR',
+  [ScaEventType.BotInteractionIssue]: 'Bot Interaction Issue',
+};
 
 // SECRETS SUMMARY ENDPOINT
 
@@ -111,6 +183,20 @@ export interface SecretsEventsQueryParameters {
   branch?: string;
   eventTypes?: string[];
 }
+
+export enum SecretsEventType {
+  NewFinding = 'new-finding',
+  NewFindings = 'new-findings',
+  NewAllowlistedFinding = 'new-allowlisted-finding',
+  NewAllowlistedFindings = 'new-allowlisted-findings',
+}
+
+export const SecretsEventTypeDescriptions: Record<SecretsEventType, string> = {
+  [ScaEventType.NewFinding]: 'New Finding',
+  [ScaEventType.NewFindings]: 'New Findings',
+  [ScaEventType.NewAllowlistedFinding]: 'New Allowlisted Finding',
+  [ScaEventType.NewAllowlistedFindings]: 'New Allowlisted Findings',
+};
 
 export type NullifyQueryOptions =
   | SastSummaryQueryOptions

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,7 @@ export interface SastSummaryQueryOptions extends BaseQueryOptions {
 }
 
 export interface SastSummaryQueryParameters {
-  githubRepositoryId?: string;
+  githubRepositoryIds?: number[];
   severity?: string;
 }
 
@@ -47,7 +47,7 @@ export interface SastEventsQueryOptions extends BaseQueryOptions {
 }
 
 export interface SastEventsQueryParameters {
-  githubRepositoryId?: string;
+  githubRepositoryIds?: number[];
   branch?: string;
   eventTypes?: string[];
 }
@@ -60,7 +60,7 @@ export interface ScaSummaryQueryOptions extends BaseQueryOptions {
 }
 
 export interface ScaSummaryQueryParameters {
-  githubRepositoryId?: string;
+  githubRepositoryIds?: number[];
   package?: string;
 }
 
@@ -72,7 +72,7 @@ export interface ScaEventsQueryOptions extends BaseQueryOptions {
 }
 
 export interface ScaEventsQueryParameters {
-  githubRepositoryId?: string;
+  githubRepositoryIds?: number[];
   branch?: string;
   eventTypes?: string[];
 }
@@ -85,7 +85,7 @@ export interface SecretsSummaryQueryOptions extends BaseQueryOptions {
 }
 
 export interface SecretsSummaryQueryParameters {
-  githubRepositoryId?: string;
+  githubRepositoryIds?: number[];
   branch?: string;
   type?: string;
   allowlisted?: boolean;
@@ -99,7 +99,7 @@ export interface SecretsEventsQueryOptions extends BaseQueryOptions {
 }
 
 export interface SecretsEventsQueryParameters {
-  githubRepositoryId?: string;
+  githubRepositoryIds?: number[];
   branch?: string;
   eventTypes?: string[];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,8 +87,8 @@ export interface SecretsSummaryQueryOptions extends BaseQueryOptions {
 export interface SecretsSummaryQueryParameters {
   githubRepositoryIds?: number[];
   branch?: string;
-  type?: string;
-  allowlisted?: boolean;
+  secretType?: string;
+  isAllowlisted?: boolean;
 }
 
 // SECRETS EVENTS ENDPOINT

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,3 +1,5 @@
+import { getTemplateSrv } from '@grafana/runtime';
+
 export const prepend_severity_idx = (severity: string) => {
   severity = severity.toUpperCase();
   switch (severity) {
@@ -12,4 +14,27 @@ export const prepend_severity_idx = (severity: string) => {
     default:
       return severity;
   }
+};
+
+export const unwrapRepositoryTemplateVariables = (githubRepositoryIdsOrQueries: Array<number | string>) => {
+  const repoIds = githubRepositoryIdsOrQueries
+    ?.map((idOrQuery) => {
+      if (typeof idOrQuery === 'number') {
+        return idOrQuery;
+      } else {
+        return getTemplateSrv()
+          .replace(idOrQuery, undefined, 'csv')
+          .split(',')
+          .map((repoId) => parseInt(repoId, 10))
+          .filter((id) => {
+            if (Number.isNaN(id)) {
+              console.error(`Selection for ${idOrQuery} variable is invalid: ${id}`);
+            }
+            return !Number.isNaN(id);
+          });
+      }
+    })
+    .flat();
+
+  return [...new Set(repoIds)];
 };


### PR DESCRIPTION
## Description

Review and merge https://github.com/Nullify-Platform/nullify-grafana-datasource/pull/21 first

An empty eventType parameter may return objects that do not conform to a known schema. This is unacceptable - by default, the eventType parameter will contain all eventType values.

## Linked Issues & PRs

- resolves <insert-issue-link>
- relates to <insert-pr-link>

[GitHub Issue Linking Docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
